### PR TITLE
Pin meta to 1.11

### DIFF
--- a/dcli_common/pubspec.lock
+++ b/dcli_common/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:

--- a/dcli_common/pubspec.yaml
+++ b/dcli_common/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/onepub-dev/dcli
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  meta: ^1.12.0
+  meta: 1.11.0
   path: ^1.9.0
   scope: ^4.1.0
 dev_dependencies:

--- a/dcli_core/pubspec.lock
+++ b/dcli_core/pubspec.lock
@@ -135,7 +135,7 @@ packages:
       path: "../dcli"
       relative: true
     source: path
-    version: "4.0.1-alpha.13"
+    version: "4.0.1-beta.1"
   dcli_common:
     dependency: "direct main"
     description:

--- a/dcli_unit_tester/pubspec.lock
+++ b/dcli_unit_tester/pubspec.lock
@@ -100,34 +100,30 @@ packages:
   dcli:
     dependency: "direct main"
     description:
-      name: dcli
-      sha256: "5a1a8451f7622fdda2761da5503838a8492dfcb890456c69178ac7c1dc1c0425"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.1-alpha.13"
+      path: "../dcli"
+      relative: true
+    source: path
+    version: "4.0.1-beta.1"
   dcli_common:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: dcli_common
-      sha256: e0eb9a0a4b7efe26fd842271c42006d3c229dd4be064ce0bbcecdd49d4a63fd2
-      url: "https://pub.dev"
-    source: hosted
+      path: "../dcli_common"
+      relative: true
+    source: path
     version: "4.0.1-alpha.11"
   dcli_core:
     dependency: "direct main"
     description:
-      name: dcli_core
-      sha256: "3c06cfaa565c8e8dbea7b6096b1b317e39c4a8c2b9ea19236a241dc2e9b426e7"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../dcli_core"
+      relative: true
+    source: path
     version: "4.0.1-alpha.11"
   dcli_terminal:
     dependency: "direct main"
     description:
-      name: dcli_terminal
-      sha256: "74716e25a604bf8bbd988311c821806561b4ae44ad10399bc119c9c0475f735a"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../dcli_terminal"
+      relative: true
+    source: path
     version: "4.0.1-alpha.11"
   equatable:
     dependency: transitive
@@ -442,4 +438,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/dcli_unit_tester/test/test_script/general/pubspec.lock
+++ b/dcli_unit_tester/test/test_script/general/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../../../../dcli"
       relative: true
     source: path
-    version: "4.0.1-alpha.13"
+    version: "4.0.1-beta.1"
   dcli_common:
     dependency: "direct overridden"
     description:

--- a/dcli_unit_tester/test/test_script/traditional_project/pubspec.lock
+++ b/dcli_unit_tester/test/test_script/traditional_project/pubspec.lock
@@ -103,7 +103,7 @@ packages:
       path: "../../../../dcli"
       relative: true
     source: path
-    version: "4.0.1-alpha.13"
+    version: "4.0.1-beta.1"
   dcli_common:
     dependency: "direct overridden"
     description:


### PR DESCRIPTION
This PR downgrades and pins the meta dependency to `1.11`. Before this PR, version solving failed with:
```
And because every version of dcli_common depends on meta ^1.12.0 and every version of flutter from sdk depends on meta 1.11.0, ... version solving failed.
```

Flutter version:
```
Flutter 3.19.5 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 300451adae (8 days ago) • 2024-03-27 21:54:07 -0500
Engine • revision e76c956498
Tools • Dart 3.3.3 • DevTools 2.31.1
```