### PR TITLE
Cross-Platform NamedLocks Reimplementation

### DIFF
--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -1,7 +1,6 @@
 name: Release executables for Linux
 
 on:
-  push:
   workflow_dispatch:
 #    tags:
 #      - '*'

--- a/.github/workflows/linux_installer.yml
+++ b/.github/workflows/linux_installer.yml
@@ -2,6 +2,7 @@ name: Release executables for Linux
 
 on:
   push:
+  workflow_dispatch:
 #    tags:
 #      - '*'
    

--- a/.github/workflows/run_specific_unit_tests.yml
+++ b/.github/workflows/run_specific_unit_tests.yml
@@ -26,18 +26,39 @@ jobs:
           cd ../dcli
           dart pub get
           cd ..
+          
 
       - name: Activate DCLI from Source
         run: |
           cd dcli
           dart pub global activate -spath .
 
-
-      - name: Run All Tests
+      - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_lock_test.test
         run: |
           echo $(pwd)
           cd dcli
-          dart test .
+          dart test test/src/util/named_lock_test.dart
+
+      - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+        run: |
+          echo $(pwd)
+          cd dcli
+          dart test test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+
+# This one keeps failing
+#      - name: Run Tests in test/src/script/commands
+#        run: |
+#          echo $(pwd)
+#          cd dcli
+#          dart test test/src/script/commands
+
+# This one keeps failing also
+#      - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
+#        run: |
+#          echo $(pwd)
+#          cd dcli
+#          dart test test/src/script/dart_project_test.dart
+
       
           
           

--- a/.github/workflows/run_specific_unit_tests.yml
+++ b/.github/workflows/run_specific_unit_tests.yml
@@ -35,13 +35,11 @@ jobs:
 
       - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_lock_test.test
         run: |
-          echo $(pwd)
           cd dcli
           dart test test/src/util/named_lock_test.dart
 
       - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |
-          echo $(pwd)
           cd dcli
           dart test test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
 

--- a/.github/workflows/run_specific_unit_tests.yml
+++ b/.github/workflows/run_specific_unit_tests.yml
@@ -1,4 +1,4 @@
-name: tool/run_unit_tests.dart
+name: tool/run_specific_unit_tests.dart
 
 on:
   push:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -34,26 +34,31 @@ jobs:
 
       - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
         run: |
+          echo pwd
           cd dcli
           dart test /test/src/script/dart_project_test.dart
 
       - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_locks_test.test
         run: |
+          echo pwd
           cd dcli
           dart test /test/src/util/named_locks_test.dart
 
       - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |
+          echo pwd
           cd dcli
           dart test /test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
 
       - name: Run Tests in test/src/script/commands
         run: |
+          echo pwd
           cd dcli
           dart test /test/src/script/commands
 
       - name: Run All Tests
         run: |
+          echo pwd
           cd dcli
           dart test .
       

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,6 +1,8 @@
 name: tool/run_unit_tests.dart
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Run All Tests
         run: |
-          echo $(pwd)
           cd dcli
           dart test .
       

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -11,11 +11,12 @@ jobs:
       matrix:
         # macos-latest is arm64 and macos-13 is x86_64 details here: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        sdk: [stable, beta, dev, 2.16.0, 2.17.0]
+        # Can comment back in to test all beta, dev, 2.16.0, 2.17.0 if needed
+        sdk: [stable]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v4.1.4
+      - uses: dart-lang/setup-dart@v1.6.4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -34,22 +34,27 @@ jobs:
 
       - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
         run: |
+          cd dcli
           dart test /test/src/script/dart_project_test.dart
 
       - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_locks_test.test
         run: |
+          cd dcli
           dart test /test/src/util/named_locks_test.dart
 
       - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |
+          cd dcli
           dart test /test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
 
       - name: Run Tests in test/src/script/commands
         run: |
+          cd dcli
           dart test /test/src/script/commands
 
       - name: Run All Tests
         run: |
+          cd dcli
           dart test .
       
           

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -25,21 +25,22 @@ jobs:
           cd ../dcli
           dart pub get
           cd ..
+          
 
       - name: Activate DCLI from Source
         run: |
           cd dcli
           dart pub global activate -spath .
 
-      - name: Run Specific Dart Project Test - test/src/script/dart_project_test.test
+      - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
         run: |
           dart test /test/src/script/dart_project_test.dart
 
-      - name: Run Specific [OLD] NamedLocks Test - test/src/util/named_locks_test.test
+      - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_locks_test.test
         run: |
           dart test /test/src/util/named_locks_test.dart
 
-      - name: Run Specific [NEW] NamedLocks Test - test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+      - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |
           dart test /test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
 

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -36,25 +36,25 @@ jobs:
         run: |
           echo $(pwd)
           cd dcli
-          dart test /test/src/script/dart_project_test.dart
+          dart test test/src/script/dart_project_test.dart
 
       - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_locks_test.test
         run: |
           echo $(pwd)
           cd dcli
-          dart test /test/src/util/named_locks_test.dart
+          dart test test/src/util/named_locks_test.dart
 
       - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |
           echo $(pwd)
           cd dcli
-          dart test /test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+          dart test test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
 
       - name: Run Tests in test/src/script/commands
         run: |
           echo $(pwd)
           cd dcli
-          dart test /test/src/script/commands
+          dart test test/src/script/commands
 
       - name: Run All Tests
         run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -34,31 +34,31 @@ jobs:
 
       - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
         run: |
-          echo pwd
+          echo $(pwd)
           cd dcli
           dart test /test/src/script/dart_project_test.dart
 
       - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_locks_test.test
         run: |
-          echo pwd
+          echo $(pwd)
           cd dcli
           dart test /test/src/util/named_locks_test.dart
 
       - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |
-          echo pwd
+          echo $(pwd)
           cd dcli
           dart test /test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
 
       - name: Run Tests in test/src/script/commands
         run: |
-          echo pwd
+          echo $(pwd)
           cd dcli
           dart test /test/src/script/commands
 
       - name: Run All Tests
         run: |
-          echo pwd
+          echo $(pwd)
           cd dcli
           dart test .
       

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -32,12 +32,6 @@ jobs:
           cd dcli
           dart pub global activate -spath .
 
-      - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
-        run: |
-          echo $(pwd)
-          cd dcli
-          dart test test/src/script/dart_project_test.dart
-
       - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_lock_test.test
         run: |
           echo $(pwd)
@@ -55,6 +49,12 @@ jobs:
           echo $(pwd)
           cd dcli
           dart test test/src/script/commands
+
+      - name: Run Specific Dart Project Test - dcli/test/src/script/dart_project_test.test
+        run: |
+          echo $(pwd)
+          cd dcli
+          dart test test/src/script/dart_project_test.dart
 
       - name: Run All Tests
         run: |

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-latest is arm64 and macos-13 is x86_64 details here: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-latest is arm64 and macos-13 is x86_64 details here: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         sdk: [stable, beta, dev, 2.16.0, 2.17.0]
 
     steps:
@@ -24,10 +25,30 @@ jobs:
           dart pub get
           cd ..
 
-      - name: run unit tests
+      - name: Activate DCLI from Source
         run: |
           cd dcli
           dart pub global activate -spath .
-          dart test
+
+      - name: Run Specific Dart Project Test - test/src/script/dart_project_test.test
+        run: |
+          dart test /test/src/script/dart_project_test.dart
+
+      - name: Run Specific [OLD] NamedLocks Test - test/src/util/named_locks_test.test
+        run: |
+          dart test /test/src/util/named_locks_test.dart
+
+      - name: Run Specific [NEW] NamedLocks Test - test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+        run: |
+          dart test /test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+
+      - name: Run Tests in test/src/script/commands
+        run: |
+          dart test /test/src/script/commands
+
+      - name: Run All Tests
+        run: |
+          dart test .
+      
           
           

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
           cd dcli
           dart test test/src/script/dart_project_test.dart
 
-      - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_locks_test.test
+      - name: Run Specific [OLD] NamedLocks Test - dcli/test/src/util/named_lock_test.test
         run: |
           echo $(pwd)
           cd dcli

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo $(pwd)
           cd dcli
-          dart test test/src/util/named_locks_test.dart
+          dart test test/src/util/named_lock_test.dart
 
       - name: Run Specific [NEW] NamedLocks Test - dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
         run: |

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -1,7 +1,6 @@
 name: Release executables for Windows
 
 on:
-  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -2,7 +2,8 @@ name: Release executables for Windows
 
 on:
   push:
-   
+  workflow_dispatch:
+
 jobs:
   build:
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dcli/tool/post_release_hook/.settings_yaml
 .idea/misc.xml
 .idea/modules.xml
 .idea/vcs.xml
+*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ dcli/test/privileged_test
 dcli/test/privileged_test
 dcli_unit_tester/bin/dcli_unit_tester
 dcli/tool/post_release_hook/.settings_yaml
+.idea/dcli.iml
+.idea/libraries/Dart_SDK.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Zeppelin ignored files
+/ZeppelinRemoteNotebooks/

--- a/dcli/lib/src/script/dart_project.dart
+++ b/dcli/lib/src/script/dart_project.dart
@@ -316,9 +316,18 @@ class DartProject {
   /// [overwrite] defaults to false.
   ///
   void compile({bool install = false, bool overwrite = false}) {
-    find('*.dart', workingDirectory: pathToProjectRoot).forEach(
-      (file) => DartScript.fromFile(file).compile(install: install, overwrite: overwrite),
+    NamedLock.guard(
+      name: _lockName,
+      execution: ExecutionCall<void, PubGetException>(
+        callable: () {
+          find('*.dart', workingDirectory: pathToProjectRoot).forEach(
+                (file) => DartScript.fromFile(file).compile(install: install, overwrite: overwrite));
+          }
+      ),
+      waiting: 'Waiting for compile to complete...',
     );
+
+
   }
 
   /// Causes a pub get to be run against the project.

--- a/dcli/lib/src/script/dart_project.dart
+++ b/dcli/lib/src/script/dart_project.dart
@@ -11,6 +11,8 @@ import 'dart:io' as io;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:pubspec_manager/pubspec_manager.dart';
+// Here simply to avoid conflicts with the old NamedLocks
+import 'package:runtime_named_locks/runtime_named_locks.dart' as runtime;
 
 import '../../dcli.dart';
 import '../../posix.dart';
@@ -30,8 +32,7 @@ part 'dart_project_creator.dart';
 class DartProject {
   /// Create a dart project on the file system at
   /// [pathTo] from the template named [templateName].
-  factory DartProject.create(
-      {required String pathTo, required String templateName}) {
+  factory DartProject.create({required String pathTo, required String templateName}) {
     _createProject(pathTo, templateName);
     return DartProject.fromPath(pathTo, search: false);
   }
@@ -55,8 +56,7 @@ class DartProject {
   /// Set [search] to false if you don't want to search up the
   /// directory tree for a pubspec.yaml.
   DartProject.fromPath(String pathToSearchFrom, {bool search = true}) {
-    _pathToProjectRoot =
-        _findProject(pathToSearchFrom, search: search) ?? pathToSearchFrom;
+    _pathToProjectRoot = _findProject(pathToSearchFrom, search: search) ?? pathToSearchFrom;
     verbose(() => 'DartProject.fromPath: $pathToProjectRoot');
   }
 
@@ -73,8 +73,7 @@ class DartProject {
   ///
   /// If [search] is true then it will search from [pathToSearchFrom]
   /// up the tree.
-  static DartProject? findProject(String pathToSearchFrom,
-      {bool search = true}) {
+  static DartProject? findProject(String pathToSearchFrom, {bool search = true}) {
     final path = _findProject(pathToSearchFrom, search: search);
 
     return path == null ? null : DartProject.fromPath(path);
@@ -116,8 +115,7 @@ class DartProject {
       /// The packageConfig is available if passed (which unit tests do)
       /// and when passed is probably the most relable means of
       /// determining the project directory.
-      return _current ??= DartProject.fromPath(
-          dirname(dirname(Uri.parse(io.Platform.packageConfig!).path)));
+      return _current ??= DartProject.fromPath(dirname(dirname(Uri.parse(io.Platform.packageConfig!).path)));
     }
     final script = DartScript.self;
     var startFrom = '.';
@@ -139,8 +137,7 @@ class DartProject {
   String get pathToDartToolDir => truepath(_pathToProjectRoot, '.dart_tool');
 
   /// Absolute path to the project's '.dart_tool/package_config.json' directory.
-  String get pathToDartToolPackageConfig =>
-      truepath(pathToDartToolDir, 'package_config.json');
+  String get pathToDartToolPackageConfig => truepath(pathToDartToolDir, 'package_config.json');
 
   /// Absolute path to the project's 'bin' directory.
   String get pathToBinDir => truepath(_pathToProjectRoot, 'bin');
@@ -161,16 +158,13 @@ class DartProject {
   String get pathToToolDir => truepath(_pathToProjectRoot, 'tool');
 
   /// Absolute pathto the project's analysis_options.yaml
-  String get pathToAnalysisOptions =>
-      _pathToPubSpec ??= join(_pathToProjectRoot, 'analysis_options.yaml');
+  String get pathToAnalysisOptions => _pathToPubSpec ??= join(_pathToProjectRoot, 'analysis_options.yaml');
 
   /// Absolute pathto the project's pubspec.yaml
-  String get pathToPubSpec =>
-      _pathToPubSpec ??= join(_pathToProjectRoot, 'pubspec.yaml');
+  String get pathToPubSpec => _pathToPubSpec ??= join(_pathToProjectRoot, 'pubspec.yaml');
 
   /// Absolute pathto the project's pubspec.lock
-  String get pathToPubSpecLock =>
-      _pathToPubSpec ??= join(_pathToProjectRoot, 'pubspec.lock');
+  String get pathToPubSpecLock => _pathToPubSpec ??= join(_pathToProjectRoot, 'pubspec.lock');
 
   /// Used by the dcli doctor command to print
   /// out the DartProjects details.
@@ -195,8 +189,7 @@ class DartProject {
     print('${label.padRight(pad)}: $value');
   }
 
-  String _makeSafe(String line) =>
-      HOME == '.' ? HOME : line.replaceAll(HOME, '<HOME>');
+  String _makeSafe(String line) => HOME == '.' ? HOME : line.replaceAll(HOME, '<HOME>');
 
   /// Searches up the directory tree from [pathToSearchFrom]
   /// for a dart package by looking for a pubspec.yaml.
@@ -217,11 +210,11 @@ class DartProject {
     return null;
   }
 
-  NamedLock? __lock;
-  static const _lockName = 'script.lock';
+  // NamedLock? __lock;
+  static const _lockName = 'dcli.script.lock.a1';
 
-  NamedLock get _lock =>
-      __lock ??= NamedLock(suffix: _lockName, lockPath: pathToProjectRoot);
+  // NamedLock get _lock =>
+  //     __lock ??= NamedLock(suffix: _lockName, lockPath: pathToProjectRoot);
 
   ///
   /// Prepare the project so it can be run.
@@ -235,36 +228,43 @@ class DartProject {
   /// If [upgrade] is true then a pub upgrade is ran rather than
   /// pub get.
   ///
-  Future<void> warmup({bool background = false, bool upgrade = false}) async {
-    await _lock.withLock(
-      () async {
-        try {
-          if (background) {
-            // we run the clean in the background
-            // by running another copy of dcli.
-            print('DCli warmup started in the background.');
-            '${DCliPaths().dcliName} '
-                    '''-v=${join(io.Directory.systemTemp.path, 'dcli.warmup.log')}'''
-                    ' warmup $pathToProjectRoot'
-                .start(
-              detached: true,
-              runInShell: true,
-              extensionSearch: false,
-            );
-          } else {
-            // print(orange('Running pub get...'));
-            if (upgrade) {
-              await _pubupgrade();
+  void warmup({bool background = false, bool upgrade = false}) {
+    runtime.NamedLock.guard(
+      name: _lockName,
+      execution: runtime.ExecutionCall<void>(
+        callable: () {
+          try {
+            if (background) {
+              // we run the clean in the background
+              // by running another copy of dcli.
+              print('DCli warmup started in the background.');
+              '${DCliPaths().dcliName} '
+                      '''-v=${join(io.Directory.systemTemp.path, 'dcli.warmup.log')}'''
+                      ' warmup $pathToProjectRoot'
+                  .start(
+                detached: true,
+                runInShell: true,
+                extensionSearch: false,
+              );
             } else {
-              await _pubget();
+              // print(orange('Running pub get...'));
+              if (upgrade) {
+                _pubupgrade();
+              } else {
+                _pubget();
+              }
             }
+          } on PubGetException {
+            print(red("\ndcli warmup failed due to the 'pub get' call failing."));
           }
-        } on PubGetException {
-          print(red("\ndcli warmup failed due to the 'pub get' call failing."));
-        }
-      },
-      waiting: 'Waiting for warmup to complete...',
+        },
+      ),
     );
+
+    // await _lock.withLock(
+    //   () async {},
+    //   waiting: 'Waiting for warmup to complete...',
+    // );
   }
 
   /// Removes any of the dart build artifacts so you have a clean directory.
@@ -276,38 +276,72 @@ class DartProject {
   /// .dart_tools
   ///
   /// Any exes for scripts in the directory.
-  Future<void> clean() async {
-    await _lock.withLock(
-      () async {
-        find(
-          '.packages',
-          types: [Find.file],
-          workingDirectory: pathToProjectRoot,
-        ).forEach(delete);
+  void clean() {
+    runtime.NamedLock.guard(
+      name: _lockName,
+      execution: runtime.ExecutionCall<void>(
+        callable: () {
+          try {
+            find(
+              '.packages',
+              types: [Find.file],
+              workingDirectory: pathToProjectRoot,
+            ).forEach(delete);
 
-        /// we cant delete directories whilst recusively scanning them.
-        final toBeDeleted = <String>[];
-        find(
-          '.dart_tool',
-          types: [Find.directory],
-          workingDirectory: pathToProjectRoot,
-        ).forEach(toBeDeleted.add);
+            /// we cant delete directories whilst recusively scanning them.
+            final toBeDeleted = <String>[];
+            find(
+              '.dart_tool',
+              types: [Find.directory],
+              workingDirectory: pathToProjectRoot,
+            ).forEach(toBeDeleted.add);
 
-        _deleteDirs(toBeDeleted);
+            _deleteDirs(toBeDeleted);
 
-        find('pubspec.lock', workingDirectory: pathToProjectRoot)
-            .forEach(delete);
+            find('pubspec.lock', workingDirectory: pathToProjectRoot).forEach(delete);
 
-        find('*.dart', workingDirectory: pathToProjectRoot)
-            .forEach((scriptPath) {
-          final script = DartScript.fromFile(scriptPath);
-          if (exists(script.pathToExe)) {
-            delete(script.pathToExe);
+            find('*.dart', workingDirectory: pathToProjectRoot).forEach((scriptPath) {
+              final script = DartScript.fromFile(scriptPath);
+              if (exists(script.pathToExe)) {
+                delete(script.pathToExe);
+              }
+            });
+          } on PubGetException {
+            print(red("\ndcli clean failed due to the 'pub get' call failing."));
           }
-        });
-      },
-      waiting: 'Waiting for clean to complete...',
+        },
+      ),
     );
+
+    // await _lock.withLock(
+    //   () async {
+    //     find(
+    //       '.packages',
+    //       types: [Find.file],
+    //       workingDirectory: pathToProjectRoot,
+    //     ).forEach(delete);
+    //
+    //     /// we cant delete directories whilst recusively scanning them.
+    //     final toBeDeleted = <String>[];
+    //     find(
+    //       '.dart_tool',
+    //       types: [Find.directory],
+    //       workingDirectory: pathToProjectRoot,
+    //     ).forEach(toBeDeleted.add);
+    //
+    //     _deleteDirs(toBeDeleted);
+    //
+    //     find('pubspec.lock', workingDirectory: pathToProjectRoot).forEach(delete);
+    //
+    //     find('*.dart', workingDirectory: pathToProjectRoot).forEach((scriptPath) {
+    //       final script = DartScript.fromFile(scriptPath);
+    //       if (exists(script.pathToExe)) {
+    //         delete(script.pathToExe);
+    //       }
+    //     });
+    //   },
+    //   waiting: 'Waiting for clean to complete...',
+    // );
   }
 
   /// Compiles all dart scripts in the project.
@@ -321,8 +355,7 @@ class DartProject {
   ///
   void compile({bool install = false, bool overwrite = false}) {
     find('*.dart', workingDirectory: pathToProjectRoot).forEach(
-      (file) => DartScript.fromFile(file)
-          .compile(install: install, overwrite: overwrite),
+      (file) => DartScript.fromFile(file).compile(install: install, overwrite: overwrite),
     );
   }
 
@@ -333,20 +366,19 @@ class DartProject {
   ///
   /// This is normally done when the project cache is first
   /// created and when a script's pubspec changes.
-  Future<void> _pubget() async {
-    await NamedLock(
-      suffix: _lockName,
-      lockPath: pathToProjectRoot,
-    ).withLock(() async {
-      final pubGet = PubGet(this);
-      if (Shell.current.isSudo) {
-        /// bugger we just screwed the cache permissions so lets fix them.
-//         'chmod -R ${env['USER']}:${env['USER']} ${PubCache().pathTo}'.run;
-        throw DartProjectException(
-            'You must compile your script before running it under sudo');
-      }
-      pubGet.run(compileExecutables: false);
-    });
+  void _pubget() {
+    runtime.NamedLock.guard(
+      name: _lockName,
+      execution: runtime.ExecutionCall<void>(callable: () {
+        final pubGet = PubGet(this);
+        if (Shell.current.isSudo) {
+          /// bugger we just screwed the cache permissions so lets fix them.
+          'chmod -R ${env['USER']}:${env['USER']} ${PubCache().pathTo}'.run;
+          throw DartProjectException('You must compile your script before running it under sudo');
+        }
+        pubGet.run(compileExecutables: false);
+      }),
+    );
   }
 
   /// Causes a pub upgrade to be run against the project.
@@ -356,21 +388,19 @@ class DartProject {
   ///
   /// This is normally done when the project cache is first
   /// created and when a script's pubspec changes.
-  Future<void> _pubupgrade() async {
-    await NamedLock(
-      suffix: _lockName,
-      lockPath: pathToProjectRoot,
-    ).withLock(() async {
-      final pubUpgrade = PubUpgrade(this);
-      if (Shell.current.isSudo) {
-        /// bugger we just screwed the cache permissions so lets fix them.
-//         'chmod -R ${env['USER']}:${env['USER']} ${PubCache().pathTo}'.run;
-
-        throw DartProjectException(
-            'You must compile your script before running it under sudo');
-      }
-      pubUpgrade.run(compileExecutables: false);
-    });
+  _pubupgrade() {
+    // Refactor with named lock guard
+    runtime.NamedLock.guard(
+        name: _lockName,
+        execution: runtime.ExecutionCall<void>(callable: () {
+          final pubUpgrade = PubUpgrade(this);
+          if (Shell.current.isSudo) {
+            /// bugger we just screwed the cache permissions so lets fix them.
+            'chmod -R ${env['USER']}:${env['USER']} ${PubCache().pathTo}'.run;
+            throw DartProjectException('You must compile your script before running it under sudo');
+          }
+          pubUpgrade.run(compileExecutables: false);
+        }));
   }
 
   // TODO(bsutton): this is still risky as pub get does a test to see if
@@ -387,8 +417,7 @@ class DartProject {
   /// * pubspec.lock
   /// *
   ///
-  bool get isReadyToRun =>
-      hasPubSpec && !DartSdk().isPubGetRequired(pathToProjectRoot);
+  bool get isReadyToRun => hasPubSpec && !DartSdk().isPubGetRequired(pathToProjectRoot);
 
   /// Returns true if this project is a flutter projects.
   ///
@@ -399,8 +428,7 @@ class DartProject {
   bool get hasPubSpec => exists(join(pathToProjectRoot, 'pubspec.yaml'));
 
   /// Returns true if the project has an 'analysis_options.yaml' file.
-  bool get hasAnalysisOptions =>
-      exists(join(pathToProjectRoot, 'analysis_options.yaml'));
+  bool get hasAnalysisOptions => exists(join(pathToProjectRoot, 'analysis_options.yaml'));
 
   void _deleteDirs(List<String> toBeDeleted) {
     for (final dir in toBeDeleted) {
@@ -410,22 +438,22 @@ class DartProject {
     }
   }
 
-  // /// Prepares the project by creating a pubspec.yaml and
-  // /// the analysis_options.yaml file.
-  // void initFiles() {
-  //   if (!hasPubSpec) {
-  //     _createPubspecFromTemplate(
-  //         pathToProjectRoot: pathToProjectRoot, pathToPubSpec:
-  // pathToPubSpec);
-  //   }
+// /// Prepares the project by creating a pubspec.yaml and
+// /// the analysis_options.yaml file.
+// void initFiles() {
+//   if (!hasPubSpec) {
+//     _createPubspecFromTemplate(
+//         pathToProjectRoot: pathToProjectRoot, pathToPubSpec:
+// pathToPubSpec);
+//   }
 
-  //   if (!hasAnalysisOptions) {
-  //     /// add pedantic to the project
-  //     _createAnalysisOptionsFromTemplate(
-  //         pathToProjectRoot: pathToProjectRoot, pathToPubSpec:
-  // pathToPubSpec);
-  //   }
-  // }
+//   if (!hasAnalysisOptions) {
+//     /// add pedantic to the project
+//     _createAnalysisOptionsFromTemplate(
+//         pathToProjectRoot: pathToProjectRoot, pathToPubSpec:
+// pathToPubSpec);
+//   }
+// }
 
 //   /// Creates a project located at [pathToProject] from the
 //passed [templatePath].
@@ -465,6 +493,5 @@ class DartProjectException extends DCliException {
 /// The requested DCli template does not exists.
 class TemplateNotFoundException extends DCliException {
   /// The requested DCli template does not exists.
-  TemplateNotFoundException(String pathTo)
-      : super('The template $pathTo does not exist.');
+  TemplateNotFoundException(String pathTo) : super('The template $pathTo does not exist.');
 }

--- a/dcli/lib/src/util/named_lock.dart
+++ b/dcli/lib/src/util/named_lock.dart
@@ -88,17 +88,18 @@ class NamedLock {
             timeout: _timeout,
         );
 
-        if(_execution.error.isSet) {
-          print('Error: ${_execution.error.get}');
+        if(_execution.successful.isSet && _execution.successful.get!) {
           await _execution.completer.future;
+          await _execution.returned;
+        } else if(_execution.error.isSet) {
           await _execution.error.get?.rethrow_();
         }
 
       } on DCliException catch(e) {
-        print('Exception caught $e : $e');
+        verbose(() => 'Exception caught for $_nameWithSuffix...  $e : $e');
         throw e..stackTrace = callingStackTrace;
       } on Exception catch (e) {
-        print('Exception caught $e : $e');
+        verbose(() => 'Exception caught for $_nameWithSuffix... $e : $e');
         throw DCliException.from(e, callingStackTrace);
       } finally {
         verbose(() => 'withLock completed for $_nameWithSuffix');

--- a/dcli/lib/src/util/named_lock.dart
+++ b/dcli/lib/src/util/named_lock.dart
@@ -48,9 +48,14 @@ class NamedLock {
   })  : _timeout = timeout,
         _description = description, _name = name;
 
-  /// The name of the lock which in-turn is used to create
-  /// a native named semaphore under the hood.
+  /// The name of the lock which is used to create the a native named semaphore under the hood.
   final String _name;
+
+  /// The tcp socket  port we use to implement
+  /// a hard lock. A port can only be opened once
+  /// so its the perfect way to create a lock that works
+  /// across processes and isolates.
+  final int port = 9003;
 
   /// Path to the directory where the lock files are stored.
   late String _lockPath;

--- a/dcli/lib/src/util/named_lock.dart
+++ b/dcli/lib/src/util/named_lock.dart
@@ -4,21 +4,18 @@
  * Written by Brett Sutton <bsutton@onepub.dev>, Jan 2022
  */
 
-import 'dart:async';
-import 'dart:developer';
-import 'dart:io';
-import 'dart:isolate';
+import 'dart:async' show Future, FutureOr, runZonedGuarded;
+import 'package:runtime_named_locks/runtime_named_locks.dart' as runtime;
+import 'package:stack_trace/stack_trace.dart' show Trace;
 
-import 'package:path/path.dart';
-import 'package:stack_trace/stack_trace.dart';
-
-import '../../dcli.dart';
+import '../../dcli.dart' show DCliException, verbose;
 
 /// A [NamedLock] can be used to control access to a resource
 /// across processes and isolates.
 class NamedLock {
   /// !!DEPRECATED!! [lockPath] was the path of the directory used
   /// to store the lock file. This is no longer used.
+  ///
   /// All code that shares the lock MUST use the
   /// same [suffix].
   /// The [suffix] is used as the suffix of the named semaphore name.
@@ -32,42 +29,33 @@ class NamedLock {
   /// infinite (null).
   ///
   /// ```dart
-  /// NamedLock(name: 'update-catalog').withLock(() {
+  /// NamedLock(name: 'update-catalog', suffix: my-script).withLock(() {
   ///   if (!exists('catalog'))
   ///     createDir('catalog');
   ///   updateCatalog();
   /// });
   /// ```
-  ///
   NamedLock({
     required this.suffix,
+    // TODO perhaps we keep this in tact and end up doing a hash on it to create the name?
     String? lockPath,
     String description = '',
-    String name = 'dcli.named.semaphore.lock',
+    String name = 'dcli.lock.name',
     Duration timeout = const Duration(seconds: 30),
   })  : _timeout = timeout,
-        _description = description, _name = name;
+        _description = description, _nameWithSuffix = [name, suffix].join('.');
 
-  /// The name of the lock which is used to create the a native named semaphore under the hood.
-  final String _name;
-
-  /// The tcp socket  port we use to implement
-  /// a hard lock. A port can only be opened once
-  /// so its the perfect way to create a lock that works
-  /// across processes and isolates.
-  final int port = 9003;
-
-  /// Path to the directory where the lock files are stored.
-  late String _lockPath;
+  /// The name of the lock which is used to create the a
+  /// native named semaphore under the hood.
+  final String _nameWithSuffix;
 
   /// The name of the lock.
   final String suffix;
+
+  /// The description of the lock for error messages.
+  /// TODO @tsavo-at-pieces - layer this into named locks package
   final String _description;
 
-  /// We maintain a lock count per
-  /// lock suffix to allow each suffix lock to be re-entrant
-  /// within a single isolate.
-  static final Map<String, int> _lockCounts = {};
 
   /// The duration to wait for a lock before timing out.
   final Duration _timeout;
@@ -78,356 +66,47 @@ class NamedLock {
   /// a log message to the console.
   ///
   /// Throws a [DCliException] if the NamedLock times out.
-  Future<void> withLock(
-    Future<void> Function() action, {
+  FutureOr<void> withLock(
+    FutureOr<void> Function() action, {
     String? waiting,
   }) async {
     final callingStackTrace = Trace.current();
-    var lockHeld = false;
-    return runZonedGuarded(() async {
+
+    final execution = runtime.ExecutionCall<FutureOr<void>, DCliException>(
+      callable: () => action(),
+      safe: true,
+    );
+
       try {
-        verbose(() => 'withLock called for $_lockFilePath');
+        verbose(() => 'withLock called for $_nameWithSuffix');
 
-        _createLockPath();
+        // Note that guarded here is the same insance as execution above
+        final _execution = runtime.NamedLock.guard<FutureOr<void>, DCliException>(
+            name: _nameWithSuffix,
+            execution: execution,
+            waiting: waiting,
+            timeout: _timeout,
+        );
 
-        if (_lockCountForName > 0 || await _takeLock(waiting)) {
-          lockHeld = true;
-          incLockCount;
-
-          await action();
+        if(_execution.error.isSet) {
+          print('Error: ${_execution.error.get}');
+          await _execution.completer.future;
+          await _execution.error.get?.rethrow_();
         }
-      } finally {
-        if (lockHeld) {
-          await _releaseLock();
-        }
-        // just in case an async exception can be thrown
-        // I'm uncertain if this is a reality.
-        lockHeld = false;
-        verbose(() => 'withLock completed for $_lockFilePath');
-      }
-    }, (e, st) async {
-      if (lockHeld) {
-        await _releaseLock();
-      }
-      verbose(() => 'Exception throw $e : $e');
-      if (e is DCliException) {
+
+      } on DCliException catch(e) {
+        print('Exception caught $e : $e');
         throw e..stackTrace = callingStackTrace;
-      } else {
+      } on Exception catch (e) {
+        print('Exception caught $e : $e');
         throw DCliException.from(e, callingStackTrace);
+      } finally {
+        verbose(() => 'withLock completed for $_nameWithSuffix');
       }
-    });
   }
 
-  void _createLockPath() {
-    if (!exists(_lockPath)) {
-      try {
-        createDir(_lockPath, recursive: true);
-      } on CreateDirException catch (_) {
-        /// we can get a race condition on the
-        /// create so just ignore it.
-      }
-    }
-  }
-
-  Future<void> _releaseLock() async {
-    if (_lockCountForName > 0) {
-      decLockCount;
-
-      /// decLockCount changes the value of _locakCountForName
-      /// but the static analyser can't see this.
-      // ignore: invariant_booleans
-      if (_lockCountForName == 0) {
-        verbose(() => 'Releasing lock: $_lockFilePath');
-
-        await _withHardLock(fn: () async => delete(_lockFilePath));
-
-        verbose(() => 'Released lock: $_lockFilePath');
-      }
-    }
-  }
-
-  int get _lockCountForName {
-    var lockCount = _lockCounts[suffix];
-    return lockCount ??= 0;
-  }
-
-  /// increments the lock count and returns
-  /// the new lock count.
-  int get incLockCount {
-    var lockCount = _lockCountForName;
-    lockCount++;
-    _lockCounts[suffix] = lockCount;
-    verbose(() => 'Incremented lock: $lockCount');
-    return lockCount;
-  }
-
-  /// decrements the lock count and returns
-  /// the new lock count.
-  int get decLockCount {
-    var lockCount = _lockCountForName;
-    lockCount--;
-    _lockCounts[suffix] = lockCount;
-
-    verbose(() => 'Decremented lock: $_lockCountForName');
-    return lockCount;
-  }
-
-  String get _lockFilePath {
-    // lock file is in the directory above the project
-    // as during preparing we delete the project directory.
-
-    final isolate = _isolateID;
-
-    return join(_lockPath, '.$pid.$isolate.$suffix');
-  }
-
-  _LockFileParts? _lockFileParts(String lockfilePath) {
-    final parts = basename(lockfilePath).split('.');
-    // it can't actually be one of our lock files
-    if (parts.length < 3) {
-      return null;
-    }
-
-    final pid = int.tryParse(parts[1]) ?? 0;
-    final isolateId = int.tryParse(parts[2]) ?? 0;
-
-    return _LockFileParts(pid, isolateId);
-  }
-
-  int get _isolateID {
-    String? isolateString;
-
-    try {
-      isolateString = Service.getIsolateId(Isolate.current);
-      // ignore: avoid_catches_without_on_clauses
-    } catch (_) {
-      /// hack until google fixes nndb problem with getIsolateID
-      /// https://github.com/dart-lang/sdk/issues/45347
-    }
-    int? isolateId;
-    if (isolateString != null) {
-      isolateString = isolateString.replaceAll('/', '_');
-      isolateString = isolateString.replaceAll(r'\', '_');
-      if (isolateString.contains('_')) {
-        /// just the numeric value.
-        isolateId = int.tryParse(isolateString.split('_')[1]);
-      }
-    }
-    return isolateId ??= Isolate.current.hashCode;
-  }
-
-  /// Attempts to take a project lock.
-  /// We wait for upto 30 seconds for an existing lock to
-  /// be released and then give up.
-  ///
-  /// We create the lock file in the virtual project directory
-  /// in the form:
-  /// <pid>.warmup.lock
-  ///
-  /// If we find an existing lock file we check if the process
-  /// that owns it is still running. If it isn't we
-  /// take a lock and delete the orphaned lock.
-  Future<bool> _takeLock(String? waiting) async {
-    var taken = false;
-    verbose(() => '_takeLock called for: $_lockFilePath');
-
-    var finalwaiting = waiting;
-
-    // wait for the lock to release or the timeout to expire
-    var waitCount = 1;
-
-    // we will be retrying every 100 ms.
-    waitCount = _timeout.inMilliseconds ~/ 100;
-    // ensure at least one retry
-    if (waitCount == 0) {
-      waitCount = 1;
-    }
-
-    /// If a valid lock file exists we don't even try to take
-    /// a hard lock.
-    /// This is to avoid a pseudo race condition under heavy load
-    /// where the lock owner can't get the hardlock as
-    /// all of the contenders constantly have it locked.
-    while (!taken && waitCount > 0) {
-      verbose(() => 'entering withHardLock $waitCount for $_lockFilePath');
-
-      if (!_validLockFileExists) {
-        await _withHardLock(
-          fn: () async {
-            // check for other lock files
-            final locks = find(
-              '*.$suffix',
-              workingDirectory: _lockPath,
-              includeHidden: true,
-              recursive: false,
-            ).toList();
-            verbose(() => red('found lock files $locks'));
-
-            var lockFiles = locks.length;
-
-            if (lockFiles == 0) {
-              // no other lock exists so we have taken a lock.
-              taken = true;
-            } else {
-              // we have found another lock file so check if it is held
-              // be a running process
-              lockFiles = _clearStaleLocks(locks, lockFiles);
-              if (lockFiles == 0) {
-                taken = true;
-              }
-            }
-
-            if (taken) {
-              final isolateID = _isolateID;
-              Settings().verbose(
-                'Taking lock ${basename(_lockFilePath)} for $isolateID',
-              );
-
-              verbose(
-                () => 'Lock Source: '
-                    // ignore: lines_longer_than_80_chars
-                    '${Trace.current(9).frames[0]}',
-              );
-              touch(_lockFilePath, create: true);
-            }
-          },
-        );
-      }
-
-      /// sleep for 100ms and then we will try again.
-      sleep(100, interval: Interval.milliseconds);
-      if (finalwaiting != null) {
-        // only print waiting message once.
-        finalwaiting = null;
-      }
-
-      waitCount--;
-    }
-
-    if (!taken) {
-      if (waitCount == 0) {
-        throw LockException(
-          'NamedLock timed out on $_description '
-          '${truepath(_lockPath)} as it is currently held',
-        );
-      } else {
-        throw LockException(
-          'Unable to lock $_description '
-          '${truepath(_lockPath)} as it is currently held',
-        );
-      }
-    }
-
-    verbose(() => 'lock Taken for: $_lockFilePath');
-
-    return taken;
-  }
-
-  /// Check if there is a valid lock file and if so
-  /// if it has a live owner.
-  bool get _validLockFileExists {
-    // check for other lock files
-    final locks = find(
-      '*.$suffix',
-      workingDirectory: _lockPath,
-      includeHidden: true,
-      recursive: false,
-    ).toList();
-
-    for (final lock in locks) {
-      final lockFileParts = _lockFileParts(lock);
-      if (lockFileParts == null) {
-        /// isn't a valid lock file so ignore.
-        continue;
-      }
-      if (_isSelf(lockFileParts.pid, lockFileParts.isolateId)) {
-        continue;
-      }
-
-      if (_isOwnerLive(lockFileParts.pid)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool _isSelf(int lockPid, int lockIsolateId) =>
-      lockIsolateId == _isolateID && lockPid == pid;
-
-  int _clearStaleLocks(List<String> locks, int lockFiles) {
-    var lockFiles0 = lockFiles;
-    for (final lock in locks) {
-      final lockFileParts = _lockFileParts(lock);
-      if (lockFileParts == null) {
-        /// isn't a valid lock file so ignore.
-        continue;
-      }
-      if (_isSelf(lockFileParts.pid, lockFileParts.isolateId)) {
-        // ignore our own lock.
-        lockFiles0--;
-        continue;
-      }
-
-      if (!_isOwnerLive(lockFileParts.pid)) {
-        // If the foreign lock file was left orphaned
-        // then we delete it.
-        if (exists(lock)) {
-          verbose(() => red('Clearing old lock file: $lock'));
-          delete(lock);
-        }
-        lockFiles0--;
-      }
-    }
-    return lockFiles0;
-  }
-
-  bool _isOwnerLive(int lockOwnerPid) =>
-      ProcessHelper().isRunning(lockOwnerPid);
-
-  Future<void> _withHardLock({
-    required Future<void> Function() fn,
-  }) async {
-    ServerSocket? socket;
-
-    try {
-      verbose(() => 'attempt bindSocket');
-      // ignore: discarded_futures
-      socket = await _bindSocket();
-
-      verbose(() => blue('Hardlock taken'));
-      await fn();
-    } finally {
-      if (socket != null) {
-        await socket.close();
-        verbose(() => blue('Hardlock released'));
-      }
-    }
-  }
-
-  Future<ServerSocket?> _bindSocket() async {
-    ServerSocket? socket;
-    try {
-      socket = await ServerSocket.bind(
-        '127.0.0.1',
-        port,
-      );
-    } on SocketException catch (e) {
-      /// no op. We expect this if the hardlock is already held.
-      verbose(e.toString);
-    }
-    return socket;
-  }
 }
 
-class _LockFileParts {
-  _LockFileParts(this.pid, this.isolateId);
-
-  int pid;
-  int isolateId;
-}
-
-///
 class LockException extends DCliException {
-  ///
   LockException(super.message);
 }

--- a/dcli/lib/src/util/named_lock.dart
+++ b/dcli/lib/src/util/named_lock.dart
@@ -40,7 +40,7 @@ class NamedLock {
     // TODO perhaps we keep this in tact and end up doing a hash on it to create the name?
     String? lockPath,
     String description = '',
-    String name = 'dcli.lock.name',
+    String name = 'dcli.lck',
     Duration timeout = const Duration(seconds: 30),
   })  : _timeout = timeout,
         _description = description, _nameWithSuffix = [name, suffix].join('.');

--- a/dcli/lib/src/util/named_lock_deprecated.dart
+++ b/dcli/lib/src/util/named_lock_deprecated.dart
@@ -1,0 +1,457 @@
+/* Copyright (C) S. Brett Sutton - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Brett Sutton <bsutton@onepub.dev>, Jan 2022
+ */
+
+import 'dart:async';
+import 'dart:developer';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:path/path.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+import '../../dcli.dart';
+
+/// A [NamedLock] can be used to control access to a resource
+/// across processes and isolates.
+///
+/// A [NamedLock] uses a combination of a UDP socket and a files
+/// to provide a locking mechanism that is guarenteed to work across
+/// isolates in the same process as well as between processes.
+///
+/// If you only need locking 'within' an isolate that you should
+/// avoid using [NamedLock] as it is a realitively slow locking
+/// mechanism as it creates a file to represent a lock.
+///
+/// To ensure that [NamedLock]s hold across processes and isolates
+/// we use a two part locking mechanism.
+/// The first part is a TCP socket (on port 9003) that we
+/// refer to as a hard lock.  The same hard lock is used for all
+/// [NamedLock]s and as such is a potential bottle neck. To limit
+/// this bottle neck we hold the hard lock for as short a period as possible.
+/// The hard lock is only used to create and delete the file based lock.
+/// As soon as a file based lock transition completes,
+///  the hard lock is released.
+///
+/// On linux a traditional file lock will not block isolates
+/// in the same process from locking the same file hence we need to use
+/// a NamedLock between isolates as well as processes.
+class NamedLock {
+  /// [lockPath] is the path of the directory used
+  /// to store the lock file.
+  /// If no lockPath is given then [Directory.systemTemp]/dcli/locks is used
+  /// to store locks.
+  /// All code that shares the lock MUST use the
+  /// same [lockPath]. It is recommended that you
+  /// pass an absolute path to ensure that the
+  /// same path is used.
+  /// The [suffix] is used as the suffix of the lockfile name.
+  /// The suffix allows multiple locks to share a single
+  /// lockPath.
+  /// The [description], if passed, is used in error messages
+  /// to describe the lock.
+  /// The [timeout] defines how long we will wait for
+  /// a lock to become available. The default [timeout] is
+  /// infinite (null).
+  ///
+  /// ```dart
+  /// NamedLock(name: 'update-catalog').withLock(() {
+  ///   if (!exists('catalog'))
+  ///     createDir('catalog');
+  ///   updateCatalog();
+  /// });
+  /// ```
+  ///
+  NamedLock({
+    required this.suffix,
+    String? lockPath,
+    String description = '',
+    Duration timeout = const Duration(seconds: 30),
+  })  : _timeout = timeout,
+        _description = description {
+    _lockPath =
+        lockPath ?? join(rootPath, Directory.systemTemp.path, 'dcli', 'locks');
+  }
+
+  /// The tcp socket  port we use to implement
+  /// a hard lock. A port can only be opened once
+  /// so its the perfect way to create a lock that works
+  /// across processes and isolates.
+  final int port = 9003;
+
+  /// Path to the directory where the lock files are stored.
+  late String _lockPath;
+
+  /// The name of the lock.
+  final String suffix;
+  final String _description;
+
+  /// We maintain a lock count per
+  /// lock suffix to allow each suffix lock to be re-entrant
+  /// within a single isolate.
+  static final Map<String, int> _lockCounts = {};
+
+  /// The duration to wait for a lock before timing out.
+  final Duration _timeout;
+
+  /// creates a lock file and then calls [action]
+  /// once [action] returns the lock is released.
+  /// If [waiting] is passed it will be used to write
+  /// a log message to the console.
+  ///
+  /// Throws a [DCliException] if the NamedLock times out.
+  Future<void> withLock(
+    Future<void> Function() action, {
+    String? waiting,
+  }) async {
+    final callingStackTrace = Trace.current();
+    var lockHeld = false;
+    return runZonedGuarded(() async {
+      try {
+        verbose(() => 'withLock called for $_lockFilePath');
+
+        _createLockPath();
+
+        if (_lockCountForName > 0 || await _takeLock(waiting)) {
+          lockHeld = true;
+          incLockCount;
+
+          await action();
+        }
+      } finally {
+        if (lockHeld) {
+          await _releaseLock();
+        }
+        // just in case an async exception can be thrown
+        // I'm uncertain if this is a reality.
+        lockHeld = false;
+        verbose(() => 'withLock completed for $_lockFilePath');
+      }
+    }, (e, st) async {
+      if (lockHeld) {
+        await _releaseLock();
+      }
+      verbose(() => 'Exception throw $e : $e');
+      if (e is DCliException) {
+        throw e..stackTrace = callingStackTrace;
+      } else {
+        throw DCliException.from(e, callingStackTrace);
+      }
+    });
+  }
+
+  void _createLockPath() {
+    if (!exists(_lockPath)) {
+      try {
+        createDir(_lockPath, recursive: true);
+      } on CreateDirException catch (_) {
+        /// we can get a race condition on the
+        /// create so just ignore it.
+      }
+    }
+  }
+
+  Future<void> _releaseLock() async {
+    if (_lockCountForName > 0) {
+      decLockCount;
+
+      /// decLockCount changes the value of _locakCountForName
+      /// but the static analyser can't see this.
+      // ignore: invariant_booleans
+      if (_lockCountForName == 0) {
+        verbose(() => 'Releasing lock: $_lockFilePath');
+
+        await _withHardLock(fn: () async => delete(_lockFilePath));
+
+        verbose(() => 'Released lock: $_lockFilePath');
+      }
+    }
+  }
+
+  int get _lockCountForName {
+    var lockCount = _lockCounts[suffix];
+    return lockCount ??= 0;
+  }
+
+  /// increments the lock count and returns
+  /// the new lock count.
+  int get incLockCount {
+    var lockCount = _lockCountForName;
+    lockCount++;
+    _lockCounts[suffix] = lockCount;
+    verbose(() => 'Incremented lock: $lockCount');
+    return lockCount;
+  }
+
+  /// decrements the lock count and returns
+  /// the new lock count.
+  int get decLockCount {
+    var lockCount = _lockCountForName;
+    lockCount--;
+    _lockCounts[suffix] = lockCount;
+
+    verbose(() => 'Decremented lock: $_lockCountForName');
+    return lockCount;
+  }
+
+  String get _lockFilePath {
+    // lock file is in the directory above the project
+    // as during preparing we delete the project directory.
+
+    final isolate = _isolateID;
+
+    return join(_lockPath, '.$pid.$isolate.$suffix');
+  }
+
+  _LockFileParts? _lockFileParts(String lockfilePath) {
+    final parts = basename(lockfilePath).split('.');
+    // it can't actually be one of our lock files
+    if (parts.length < 3) {
+      return null;
+    }
+
+    final pid = int.tryParse(parts[1]) ?? 0;
+    final isolateId = int.tryParse(parts[2]) ?? 0;
+
+    return _LockFileParts(pid, isolateId);
+  }
+
+  int get _isolateID {
+    String? isolateString;
+
+    try {
+      isolateString = Service.getIsolateId(Isolate.current);
+      // ignore: avoid_catches_without_on_clauses
+    } catch (_) {
+      /// hack until google fixes nndb problem with getIsolateID
+      /// https://github.com/dart-lang/sdk/issues/45347
+    }
+    int? isolateId;
+    if (isolateString != null) {
+      isolateString = isolateString.replaceAll('/', '_');
+      isolateString = isolateString.replaceAll(r'\', '_');
+      if (isolateString.contains('_')) {
+        /// just the numeric value.
+        isolateId = int.tryParse(isolateString.split('_')[1]);
+      }
+    }
+    return isolateId ??= Isolate.current.hashCode;
+  }
+
+  /// Attempts to take a project lock.
+  /// We wait for upto 30 seconds for an existing lock to
+  /// be released and then give up.
+  ///
+  /// We create the lock file in the virtual project directory
+  /// in the form:
+  /// <pid>.warmup.lock
+  ///
+  /// If we find an existing lock file we check if the process
+  /// that owns it is still running. If it isn't we
+  /// take a lock and delete the orphaned lock.
+  Future<bool> _takeLock(String? waiting) async {
+    var taken = false;
+    verbose(() => '_takeLock called for: $_lockFilePath');
+
+    var finalwaiting = waiting;
+
+    // wait for the lock to release or the timeout to expire
+    var waitCount = 1;
+
+    // we will be retrying every 100 ms.
+    waitCount = _timeout.inMilliseconds ~/ 100;
+    // ensure at least one retry
+    if (waitCount == 0) {
+      waitCount = 1;
+    }
+
+    /// If a valid lock file exists we don't even try to take
+    /// a hard lock.
+    /// This is to avoid a pseudo race condition under heavy load
+    /// where the lock owner can't get the hardlock as
+    /// all of the contenders constantly have it locked.
+    while (!taken && waitCount > 0) {
+      verbose(() => 'entering withHardLock $waitCount for $_lockFilePath');
+
+      if (!_validLockFileExists) {
+        await _withHardLock(
+          fn: () async {
+            // check for other lock files
+            final locks = find(
+              '*.$suffix',
+              workingDirectory: _lockPath,
+              includeHidden: true,
+              recursive: false,
+            ).toList();
+            verbose(() => red('found lock files $locks'));
+
+            var lockFiles = locks.length;
+
+            if (lockFiles == 0) {
+              // no other lock exists so we have taken a lock.
+              taken = true;
+            } else {
+              // we have found another lock file so check if it is held
+              // be a running process
+              lockFiles = _clearStaleLocks(locks, lockFiles);
+              if (lockFiles == 0) {
+                taken = true;
+              }
+            }
+
+            if (taken) {
+              final isolateID = _isolateID;
+              Settings().verbose(
+                'Taking lock ${basename(_lockFilePath)} for $isolateID',
+              );
+
+              verbose(
+                () => 'Lock Source: '
+                    // ignore: lines_longer_than_80_chars
+                    '${Trace.current(9).frames[0]}',
+              );
+              touch(_lockFilePath, create: true);
+            }
+          },
+        );
+      }
+
+      /// sleep for 100ms and then we will try again.
+      sleep(100, interval: Interval.milliseconds);
+      if (finalwaiting != null) {
+        // only print waiting message once.
+        finalwaiting = null;
+      }
+
+      waitCount--;
+    }
+
+    if (!taken) {
+      if (waitCount == 0) {
+        throw LockException(
+          'NamedLock timed out on $_description '
+          '${truepath(_lockPath)} as it is currently held',
+        );
+      } else {
+        throw LockException(
+          'Unable to lock $_description '
+          '${truepath(_lockPath)} as it is currently held',
+        );
+      }
+    }
+
+    verbose(() => 'lock Taken for: $_lockFilePath');
+
+    return taken;
+  }
+
+  /// Check if there is a valid lock file and if so
+  /// if it has a live owner.
+  bool get _validLockFileExists {
+    // check for other lock files
+    final locks = find(
+      '*.$suffix',
+      workingDirectory: _lockPath,
+      includeHidden: true,
+      recursive: false,
+    ).toList();
+
+    for (final lock in locks) {
+      final lockFileParts = _lockFileParts(lock);
+      if (lockFileParts == null) {
+        /// isn't a valid lock file so ignore.
+        continue;
+      }
+      if (_isSelf(lockFileParts.pid, lockFileParts.isolateId)) {
+        continue;
+      }
+
+      if (_isOwnerLive(lockFileParts.pid)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _isSelf(int lockPid, int lockIsolateId) =>
+      lockIsolateId == _isolateID && lockPid == pid;
+
+  int _clearStaleLocks(List<String> locks, int lockFiles) {
+    var lockFiles0 = lockFiles;
+    for (final lock in locks) {
+      final lockFileParts = _lockFileParts(lock);
+      if (lockFileParts == null) {
+        /// isn't a valid lock file so ignore.
+        continue;
+      }
+      if (_isSelf(lockFileParts.pid, lockFileParts.isolateId)) {
+        // ignore our own lock.
+        lockFiles0--;
+        continue;
+      }
+
+      if (!_isOwnerLive(lockFileParts.pid)) {
+        // If the foreign lock file was left orphaned
+        // then we delete it.
+        if (exists(lock)) {
+          verbose(() => red('Clearing old lock file: $lock'));
+          delete(lock);
+        }
+        lockFiles0--;
+      }
+    }
+    return lockFiles0;
+  }
+
+  bool _isOwnerLive(int lockOwnerPid) =>
+      ProcessHelper().isRunning(lockOwnerPid);
+
+  Future<void> _withHardLock({
+    required Future<void> Function() fn,
+  }) async {
+    ServerSocket? socket;
+
+    try {
+      verbose(() => 'attempt bindSocket');
+      // ignore: discarded_futures
+      socket = await _bindSocket();
+
+      verbose(() => blue('Hardlock taken'));
+      await fn();
+    } finally {
+      if (socket != null) {
+        await socket.close();
+        verbose(() => blue('Hardlock released'));
+      }
+    }
+  }
+
+  Future<ServerSocket?> _bindSocket() async {
+    ServerSocket? socket;
+    try {
+      socket = await ServerSocket.bind(
+        '127.0.0.1',
+        port,
+      );
+    } on SocketException catch (e) {
+      /// no op. We expect this if the hardlock is already held.
+      verbose(e.toString);
+    }
+    return socket;
+  }
+}
+
+class _LockFileParts {
+  _LockFileParts(this.pid, this.isolateId);
+
+  int pid;
+  int isolateId;
+}
+
+///
+class LockException extends DCliException {
+  ///
+  LockException(super.message);
+}

--- a/dcli/pubspec.yaml
+++ b/dcli/pubspec.yaml
@@ -41,6 +41,10 @@ dependencies:
   validators2: ^5.0.0
   win32: ">=4.1.4 <5.4.0"
   yaml: ^3.0.0
+  runtime_named_locks:
+    git:
+      url: https://github.com/open-runtime/named_locks
+      ref: aot_monorepo_compat
 dev_dependencies:
   dcli_test: any
   hex: ^0.2.0

--- a/dcli/pubspec.yaml
+++ b/dcli/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   validators2: ^5.0.0
   win32: ">=4.1.4 <5.4.0"
   yaml: ^3.0.0
-  runtime_named_locks: ^1.0.0-beta.3
+  runtime_named_locks: ^1.0.0-beta.6
 
 dev_dependencies:
   dcli_test: any

--- a/dcli/pubspec.yaml
+++ b/dcli/pubspec.yaml
@@ -41,10 +41,8 @@ dependencies:
   validators2: ^5.0.0
   win32: ">=4.1.4 <5.4.0"
   yaml: ^3.0.0
-  runtime_named_locks:
-    git:
-      url: https://github.com/open-runtime/named_locks
-      ref: aot_monorepo_compat
+  runtime_named_locks: ^1.0.0-beta.3
+
 dev_dependencies:
   dcli_test: any
   hex: ^0.2.0

--- a/dcli/pubspec_overrides.yaml
+++ b/dcli/pubspec_overrides.yaml
@@ -8,5 +8,6 @@ dependency_overrides:
   dcli_terminal:
     path: ../dcli_terminal
 
+
   # pubspec_manager:
   #   path: ../../pubspec_manager

--- a/dcli/test/src/script/commands/warmup_test.dart
+++ b/dcli/test/src/script/commands/warmup_test.dart
@@ -17,9 +17,9 @@ void main() {
     test('warmup ', () async {
       await TestFileSystem().withinZone((fs) async {
         final projectPath = join(fs.fsRoot, 'test_script/general');
-        final project = DartProject.fromPath(projectPath);
-        await project.clean();
-        await project.warmup();
+        final project = DartProject.fromPath(projectPath)
+          ..clean()
+          ..warmup();
 
         expect(exists(join(projectPath, '.dart_tool')), equals(true));
         expect(exists(join(projectPath, 'pubspec.lock')), equals(true));

--- a/dcli/test/src/script/dart_project_test.dart
+++ b/dcli/test/src/script/dart_project_test.dart
@@ -7,6 +7,8 @@ library;
  * Written by Brett Sutton <bsutton@onepub.dev>, Jan 2022
  */
 
+import 'dart:io';
+
 import 'package:dcli/dcli.dart';
 import 'package:dcli_core/dcli_core.dart' as core;
 import 'package:path/path.dart' hide equals;
@@ -33,8 +35,9 @@ void main() {
     test('Create project full with --template', () async {
       //    await TestFileSystem().withinZone((fs) async {
 //        InstallCommand().initTemplates();
+    print(Directory.current.parent.path);
 
-      final dcliRoot = dirname(DartProject.self.pathToProjectRoot);
+      final dcliRoot = Directory.current.parent.path;
 
       await core.withTempDirAsync((tempDir) async {
         const projectName = 'full_test';

--- a/dcli/test/src/script/dart_project_test.dart
+++ b/dcli/test/src/script/dart_project_test.dart
@@ -7,8 +7,6 @@ library;
  * Written by Brett Sutton <bsutton@onepub.dev>, Jan 2022
  */
 
-import 'dart:io';
-
 import 'package:dcli/dcli.dart';
 import 'package:dcli_core/dcli_core.dart' as core;
 import 'package:path/path.dart' hide equals;
@@ -35,9 +33,8 @@ void main() {
     test('Create project full with --template', () async {
       //    await TestFileSystem().withinZone((fs) async {
 //        InstallCommand().initTemplates();
-    print(Directory.current.parent.path);
 
-      final dcliRoot = Directory.current.parent.path;
+      final dcliRoot = dirname(DartProject.self.pathToProjectRoot);
 
       await core.withTempDirAsync((tempDir) async {
         const projectName = 'full_test';

--- a/dcli/test/src/util/named_lock_test.dart
+++ b/dcli/test/src/util/named_lock_test.dart
@@ -119,7 +119,7 @@ FutureOr<void> writeToLog(String data) {
   final parts = data.split(';');
   final message = parts[0];
   final log = parts[1];
-  NamedLock(suffix: 'test.lock').withLock(()  {
+  NamedLock(suffix: 'test').withLock(()  {
     var count = 0;
     for (var i = 0; i < 4; i++) {
       final l = '$message + ${count++}';

--- a/dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+++ b/dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
@@ -1,0 +1,212 @@
+#! /usr/bin/env dcli
+
+@Timeout(Duration(minutes: 10))
+library;
+
+/* Copyright (C) S. Brett Sutton - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Brett Sutton <bsutton@onepub.dev>, Jan 2022
+ */
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:async/async.dart';
+import 'package:dcli/dcli.dart' hide NamedLock;
+import 'package:dcli_core/dcli_core.dart' as core;
+import 'package:path/path.dart' hide equals;
+import 'package:runtime_named_locks/runtime_named_locks.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('lock path', () {
+    final lockPath = join(rootPath, Directory.systemTemp.path, 'dcli', 'locks');
+    print(lockPath);
+  });
+
+  test('unsafe exception catch', () async {
+    final execution = ExecutionCall<void, DCliException>(
+      callable: () => throw DCliException('fake exception'),
+    );
+
+    expect(
+          () => NamedLock.guard<void, DCliException>(
+        name: 'unsafe.exception.lock',
+        execution: execution,
+      ),
+      throwsA(isA<DCliException>()),
+    );
+  });
+
+  test('safe exception catch', () async {
+    final execution = ExecutionCall<void, DCliException>(
+      callable: () => throw DCliException('fake exception'),
+      safe: true,
+    );
+
+    final guarded = NamedLock.guard<void, DCliException>(
+      name: 'safe.exception.lock',
+      execution: execution,
+    );
+
+    expect(guarded.successful.get, false);
+    expect(guarded.error.get?.anticipated.get, isA<DCliException>());
+    expect(
+          () => guarded.error.get?.rethrow_(),
+      throwsA(isA<DCliException>()),
+    );
+  });
+
+  test(
+    'File Operations with NamedLock.guard',
+        () async {
+      await core.withTempDirAsync(
+            (fs) async {
+          await core.withTempFileAsync((logFile) async {
+            print('logfile: $logFile');
+            logFile.truncate();
+
+            final portBack = await spawn('background', logFile);
+            final portMid = await spawn('middle', logFile);
+            final portFore = await spawn('foreground', logFile);
+
+            await portBack.first;
+            await portMid.first;
+            await portFore.first;
+
+            print('readling logfile');
+
+            final actual = read(logFile).toList();
+
+            expect(
+              actual,
+              unorderedEquals(<String>[
+                'background + 0',
+                'background + 1',
+                'background + 2',
+                'background + 3',
+                'middle + 0',
+                'middle + 1',
+                'middle + 2',
+                'middle + 3',
+                'foreground + 0',
+                'foreground + 1',
+                'foreground + 2',
+                'foreground + 3',
+              ]),
+            );
+          });
+        },
+        keep: true,
+      );
+    },
+  );
+
+  test(
+    'Thrash Test',
+        () async {
+      Settings().setVerbose(enabled: false);
+      if (exists(_lockCheckPath)) {
+        deleteDir(_lockCheckPath);
+      }
+
+      createDir(_lockCheckPath, recursive: true);
+
+      final group = FutureGroup<dynamic>();
+
+      final workers = <Worker>[];
+      for (var i = 0; i < 10; i++) {
+        print('spawning worker $i');
+        final workerIsolate = Isolate.spawn(worker, i, paused: true);
+        final iWorker = Worker(await workerIsolate);
+        workers.add(iWorker);
+        group.add(iWorker.waitForExit());
+      }
+      group.close();
+
+      await group.future;
+
+      expect(exists(_lockFailedPath), equals(false));
+    },
+    timeout: const Timeout(Duration(minutes: 30)),
+    skip: false,
+  );
+}
+
+Future<ReceivePort> spawn(String message, String logFile) async {
+  final back = await Isolate.spawn(writeToLog, '$message;$logFile', paused: true);
+  final port = ReceivePort();
+  back
+    ..addOnExitListener(port.sendPort)
+    ..resume(back.pauseCapability!);
+  return port;
+}
+
+void writeToLog(String data) {
+  final parts = data.split(';');
+  final message = parts[0];
+  final log = parts[1];
+
+  NamedLock.guard(
+    name: 'test.log.lock',
+    execution: ExecutionCall(callable: () {
+      var count = 0;
+      for (var i = 0; i < 4; i++) {
+        final l = '$message + ${count++}';
+        print(l);
+        log.append(l);
+        sleep(1);
+      }
+    }),
+  );
+
+  print('Finished Write to Log for $message');
+}
+
+const _lockCheckPath = '/tmp/lockcheck';
+final _lockFailedPath = join(_lockCheckPath, 'lock_failed');
+
+/// must be a global function as we us it to spawn an isolate
+Future<void> worker(int instance) async {
+  Settings().setVerbose(enabled: false);
+  print('starting worker instance $instance ${DateTime.now()}');
+
+  NamedLock.guard(
+    name: 'gshared-compile.lock',
+    execution: ExecutionCall(callable: () {
+      print('acquired lock worker $instance  ${DateTime.now()}');
+      final inLockPath = join(_lockCheckPath, 'inlock');
+
+      /// If the [inLockPath] file exists
+      /// then the lock has been breached.
+      if (exists(inLockPath)) {
+        touch(_lockFailedPath, create: true);
+        throw DCliException(
+          'NamedLock for $instance failed as another lock is active',
+        );
+      }
+
+      touch(inLockPath, create: true);
+
+      sleep(2);
+      print('finished work $instance  ${DateTime.now()}');
+      delete(inLockPath);
+    }),
+  );
+
+  print('released lock $instance  ${DateTime.now()}');
+}
+
+class Worker {
+  Worker(this.isolate) : exitPort = ReceivePort() {
+    isolate
+      ..addOnExitListener(exitPort.sendPort)
+      ..resume(isolate.pauseCapability!);
+  }
+
+  Future<dynamic> waitForExit() async => exitPort.first;
+  Isolate isolate;
+  ReceivePort exitPort;
+}

--- a/dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
+++ b/dcli/test/src/util/named_lock_test_with_runtime_named_locks_package_test.dart
@@ -21,10 +21,6 @@ import 'package:runtime_named_locks/runtime_named_locks.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('lock path', () {
-    final lockPath = join(rootPath, Directory.systemTemp.path, 'dcli', 'locks');
-    print(lockPath);
-  });
 
   test('unsafe exception catch', () async {
     final execution = ExecutionCall<void, DCliException>(

--- a/dcli/tool/critical_test/pre_hook/setup.dart
+++ b/dcli/tool/critical_test/pre_hook/setup.dart
@@ -57,12 +57,11 @@ Future<void> main(List<String> args) async {
   // ignore: discarded_futures
   await capture(() async {
     // warm up the dcli project
-    await DartProject.self.warmup();
+    DartProject.self.warmup();
   }, progress: Progress.printStdErr());
 
   /// warm up all test packages.
-  for (final pubspec
-      in find('pubspec.yaml', workingDirectory: projectRoot).toList()) {
+  for (final pubspec in find('pubspec.yaml', workingDirectory: projectRoot).toList()) {
     if (DartSdk().isPubGetRequired(dirname(pubspec))) {
       print('Running pub get in ${dirname(pubspec)}');
       await capture(() async {

--- a/dcli/tool/purge.dart
+++ b/dcli/tool/purge.dart
@@ -16,6 +16,6 @@ import 'package:dcli/dcli.dart';
 /// For details on installing dcli.
 ///
 
-void main(List<String> args) async {
-  await DartProject.fromPath('.').clean();
+void main(List<String> args) {
+  DartProject.fromPath('.').clean();
 }

--- a/dcli_core/pubspec.lock
+++ b/dcli_core/pubspec.lock
@@ -390,6 +390,24 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  runtime_named_locks:
+    dependency: transitive
+    description:
+      path: "."
+      ref: aot_monorepo_compat
+      resolved-ref: "3acd49b3fc0821e114abdd0e5461ccbb567faf89"
+      url: "https://github.com/open-runtime/named_locks"
+    source: git
+    version: "0.0.1"
+  runtime_native_semaphores:
+    dependency: transitive
+    description:
+      path: "."
+      ref: aot_monorepo_compat
+      resolved-ref: "6856ec500dbfbd19d7360bf8abd2f227916888d2"
+      url: "https://github.com/open-runtime/native_semaphores"
+    source: git
+    version: "0.0.5"
   scope:
     dependency: "direct main"
     description:

--- a/dcli_sdk/pubspec.lock
+++ b/dcli_sdk/pubspec.lock
@@ -132,37 +132,42 @@ packages:
   dcli:
     dependency: "direct main"
     description:
-      path: "../dcli"
-      relative: true
-    source: path
+      name: dcli
+      sha256: c076448cee6fe563e1964ade9d4653d855e69d204547791fff0d0fe96c7bd75a
+      url: "https://pub.dev"
+    source: hosted
     version: "4.0.1-beta.4"
   dcli_common:
     dependency: "direct main"
     description:
-      path: "../dcli_common"
-      relative: true
-    source: path
+      name: dcli_common
+      sha256: c8af0ed248e67b7293cc7ca24a11cc6f3762009ce2a4d0d03c1368e6b0f15fb9
+      url: "https://pub.dev"
+    source: hosted
     version: "4.0.1-beta.4"
   dcli_core:
     dependency: "direct main"
     description:
-      path: "../dcli_core"
-      relative: true
-    source: path
+      name: dcli_core
+      sha256: "915b6d7aa9cc039de4be263ecbdac0d372286059f5dba02a8b171748afb4883c"
+      url: "https://pub.dev"
+    source: hosted
     version: "4.0.1-beta.4"
   dcli_terminal:
     dependency: "direct main"
     description:
-      path: "../dcli_terminal"
-      relative: true
-    source: path
+      name: dcli_terminal
+      sha256: "5449d06b49966796237c5953abc8763dfbc3c29d180ba41f8e182d76c8379840"
+      url: "https://pub.dev"
+    source: hosted
     version: "4.0.1-beta.4"
   dcli_test:
     dependency: "direct dev"
     description:
-      path: "../dcli_test"
-      relative: true
-    source: path
+      name: dcli_test
+      sha256: "8d41cedcfe39f6a9bedbc1a0e215fa082b52508beb8a79b38efcd484ff988c59"
+      url: "https://pub.dev"
+    source: hosted
     version: "4.0.1-beta.4"
   equatable:
     dependency: transitive
@@ -413,12 +418,13 @@ packages:
     source: hosted
     version: "4.1.0"
   settings_yaml:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../settings_yaml"
-      relative: true
-    source: path
-    version: "8.1.0-beta.1"
+      name: settings_yaml
+      sha256: abfd2a6a2c48883154ffe11ddd4f72ce43cc2d7f030ae060f7237fb3b2bddbf7
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0-alpha.2"
   shelf:
     dependency: transitive
     description:

--- a/dcli_sdk/pubspec_overrides.git.yaml
+++ b/dcli_sdk/pubspec_overrides.git.yaml
@@ -1,0 +1,24 @@
+dependency_overrides:
+  dcli:
+    git:
+      url: https://github.com/open-runtime/dcli.git
+      path: dcli
+  dcli_common:
+    git:
+      url: https://github.com/open-runtime/dcli.git
+      path: dcli_common
+  dcli_core:
+    git:
+      url: https://github.com/open-runtime/dcli.git
+      path: dcli_core
+  dcli_test:
+    git:
+      url: https://github.com/open-runtime/dcli.git
+      path: dcli_test
+  dcli_terminal:
+    git:
+      url: https://github.com/open-runtime/dcli.git
+      path: dcli_terminal
+  settings_yaml:
+    git:
+      url: https://github.com/open-runtime/settings_yaml.git

--- a/dcli_test/lib/src/test_file_system.dart
+++ b/dcli_test/lib/src/test_file_system.dart
@@ -341,7 +341,7 @@ dependency_overrides:
 
       // ignore: discarded_futures
       await capture(() async {
-        await DartProject.fromPath(dirname(pathToPubspec))
+        DartProject.fromPath(dirname(pathToPubspec))
             .warmup(upgrade: true);
       }, progress: Progress.printStdErr());
     });
@@ -375,7 +375,7 @@ dependency_overrides:
       }
 
       await capture(() async {
-        await DartProject.fromPath(pathToTools).warmup();
+        DartProject.fromPath(pathToTools).warmup();
       }, progress: Progress.printStdErr());
 
       await NamedLock(suffix: 'compile').withLock(() async {

--- a/dcli_test/pubspec_overrides.yaml
+++ b/dcli_test/pubspec_overrides.yaml
@@ -8,6 +8,3 @@ dependency_overrides:
   dcli_terminal: 
     path: ../dcli_terminal
 
-
-  settings_yaml:
-    path: ../../settings_yaml

--- a/template/project/full/pubspec.lock
+++ b/template/project/full/pubspec.lock
@@ -185,10 +185,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.2.1"
   http_parser:
     dependency: transitive
     description:
@@ -309,6 +309,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  runtime_named_locks:
+    dependency: transitive
+    description:
+      name: runtime_named_locks
+      sha256: cf03fc169dedd516a031be2ac95ef8c4d3446c22819ec92c6756e3fd926a059c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-beta.3"
+  runtime_native_semaphores:
+    dependency: transitive
+    description:
+      name: runtime_native_semaphores
+      sha256: "6703b07c01a2856bb5dc8d12e4e94e05cfcfcc35eddfb705a1de62140a5cdd14"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-beta.4"
   scope:
     dependency: transitive
     description:
@@ -320,10 +336,11 @@ packages:
   settings_yaml:
     dependency: "direct main"
     description:
-      path: "../../../../settings_yaml"
-      relative: true
-    source: path
-    version: "8.1.0-beta.1"
+      name: settings_yaml
+      sha256: abfd2a6a2c48883154ffe11ddd4f72ce43cc2d7f030ae060f7237fb3b2bddbf7
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0-alpha.2"
   source_span:
     dependency: transitive
     description:
@@ -420,6 +437,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   win32:
     dependency: transitive
     description:
@@ -438,4 +463,3 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: any

--- a/template/project/full/pubspec.yaml
+++ b/template/project/full/pubspec.yaml
@@ -2,15 +2,15 @@ name: full
 version: 0.0.1
 description: A sample command-line application that installs and runs mailhog
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter:
+  sdk: '>=3.2.0 <4.0.0'
+
 dependencies:
-  args: ^2.3.1
+  args: ^2.5.0
   dcli: 4.0.1-beta.3
   dcli_core: 4.0.1-beta.3
-  http: ^0.13.4
-  path: ^1.8.1
-  settings_yaml: ^8.1.0-alpha.2
+  http: ^1.2.1
+  path: ^1.9.0
+  settings_yaml: ^8.0.1
 dev_dependencies:
   lint_hard: ^4.0.0
 executables:

--- a/template/project/full/pubspec_overrides.yaml
+++ b/template/project/full/pubspec_overrides.yaml
@@ -5,9 +5,5 @@ dependency_overrides:
     path: ../../../dcli_common
   dcli_core: 
     path: ../../../dcli_core
-  dcli_terminal: 
+  dcli_terminal:
     path: ../../../dcli_terminal
-
-
-  settings_yaml: 
-    path: ../../../../settings_yaml


### PR DESCRIPTION
Hey @bsutton - putting this here so that you and I can both start testing this together to make sure everything stays in tact. 

You likely know where the breaks would occur better than I but I wanted to share how I initially thought about refactoring dart_project.dart file with the updated NamedLocks guard. 

That said - if you're thinking it's really important for end users to still have access to the old NamedLocks class I can re-implement its' internals with the primitives that are found in [named_locks](https://github.com/open-runtime/named_locks) pretty easily I believe. The only caveat is that this new NamedLocks system runs on Native Semaphores across Unix and Windows i.e. building on the [native_semaphores](https://github.com/open-runtime/native_semaphores) codebase and doesn't rely on the filesystem i.e. there isn't support for file paths as Named Semaphores are OS wide. 

The other thing to note is that right now it supports cross process locking and reentrant behavior within a process. It is able to keep track of the counts reentrantly but it doesn't keep track of reentrant counts across process (yet). If this is needed by DCLI or the community this can be implemented with shared memory or mmap pretty easily. 

Let me know thoughts on some of this but most importantly I'm just looking to get your feedback on if it works as expected for the DCLI use case. Perhaps you can pull this branch down and do some testing in your environment and then circle back here. 

Let me know thoughts 🙏🤝

Cheers, 
-Tsavo