### PR TITLE
fix ProgressMixin.firstLine throwing if there are no lines

### DIFF
--- a/dcli/lib/src/progress/progress_mixin.dart
+++ b/dcli/lib/src/progress/progress_mixin.dart
@@ -5,9 +5,9 @@ mixin ProgressMixin implements Progress {
   // int get exitCode => throw UnimplementedError();
 
   /// Returns the first line from the command or
-  /// null if no lines where returned
+  /// null if no lines were returned
   @override
-  String? get firstLine => lines.first;
+  String? get firstLine => lines.firstOrNull;
 
   @override
   void forEach(void Function(String line) action) {


### PR DESCRIPTION
This PR makes `ProgressMixin.firstLine` return `lines.firstOrNull` instead of `lines.first`, returning null if the command returned no lines, which is the expected behavior according to the doc comment.

An example command that would throw and that is fixed by this PR is:
```dart
'grep abc empty.txt'.start(nothrow: true).firstLine;
```