### PR TITLE
Add custom error message parameter for ask() function

### DIFF
--- a/.idea/easycode.ignore
+++ b/.idea/easycode.ignore
@@ -1,0 +1,13 @@
+node_modules/
+dist/
+vendor/
+cache/
+.*/
+*.min.*
+*.test.*
+*.spec.*
+*.bundle.*
+*.bundle-min.*
+*.*.js
+*.*.ts
+*.log

--- a/dcli/.idea/.gitignore
+++ b/dcli/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/dcli/.idea/dcli.iml
+++ b/dcli/.idea/dcli.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>

--- a/dcli/.idea/easycode.ignore
+++ b/dcli/.idea/easycode.ignore
@@ -1,0 +1,13 @@
+node_modules/
+dist/
+vendor/
+cache/
+.*/
+*.min.*
+*.test.*
+*.spec.*
+*.bundle.*
+*.bundle-min.*
+*.*.js
+*.*.ts
+*.log

--- a/dcli/lib/src/functions/ask.dart
+++ b/dcli/lib/src/functions/ask.dart
@@ -102,14 +102,15 @@ typedef CustomAskPrompt = String Function(
 ///
 ///```
 String ask(
-  String prompt, {
-  bool toLower = false,
-  bool hidden = false,
-  bool required = true,
-  String? defaultValue,
-  CustomAskPrompt customPrompt = Ask.defaultPrompt,
-  AskValidator validator = Ask.dontCare,
-}) =>
+    String prompt, {
+      bool toLower = false,
+      bool hidden = false,
+      bool required = true,
+      String? defaultValue,
+      CustomAskPrompt customPrompt = Ask.defaultPrompt,
+      AskValidator validator = Ask.dontCare,
+      String? customErrorMessage,
+    }) =>
     Ask()._ask(
       prompt,
       toLower: toLower,
@@ -118,6 +119,7 @@ String ask(
       defaultValue: defaultValue,
       customPrompt: customPrompt,
       validator: validator,
+      customErrorMessage: customErrorMessage,
     );
 
 // ignore: avoid_clas
@@ -131,17 +133,18 @@ class Ask extends core.DCliFunction {
   /// Reads user input from stdin and returns it as a string.
   /// [prompt]
   String _ask(
-    String prompt, {
-    required bool hidden,
-    required bool required,
-    required AskValidator validator,
-    required CustomAskPrompt customPrompt,
-    bool toLower = false,
-    String? defaultValue,
-  }) {
+      String prompt, {
+        required bool hidden,
+        required bool required,
+        required AskValidator validator,
+        required CustomAskPrompt customPrompt,
+        bool toLower = false,
+        String? defaultValue,
+        String? customErrorMessage,
+      }) {
     ArgumentError.checkNotNull(prompt);
     core.verbose(
-      () => 'ask:  $prompt toLower: $toLower hidden: $hidden '
+          () => 'ask:  $prompt toLower: $toLower hidden: $hidden '
           'required: $required '
           'defaultValue: ${hidden ? '******' : defaultValue}',
     );
@@ -172,10 +175,10 @@ class Ask extends core.DCliFunction {
 
       try {
         if (required) {
-          const _AskRequired().validate(line);
+          const _AskRequired().validate(line,customErrorMessage);
         }
         verbose(() => 'ask: pre validation "$line"');
-        line = validator.validate(line);
+        line = validator.validate(line, customErrorMessage);
         verbose(() => 'ask: post validation "$line"');
         valid = true;
       } on AskValidatorException catch (e) {
@@ -313,9 +316,9 @@ class Ask extends core.DCliFunction {
   /// list of available inputs.
   /// By default [caseSensitive] matches are off.
   static AskValidator inList(
-    List<Object> validItems, {
-    bool caseSensitive = false,
-  }) =>
+      List<Object> validItems, {
+        bool caseSensitive = false,
+      }) =>
       _AskValidatorList(validItems, caseSensitive: caseSensitive);
 
   /// The user must enter a non-empty string.
@@ -369,14 +372,14 @@ abstract class AskValidator {
   /// The validate method is called when the user hits the enter key.
   /// If the validation succeeds the validated line is returned.
   @visibleForTesting
-  String validate(String line);
+  String validate(String line,String? customErrorMessage);
 }
 
 /// The default validator that considers any input as valid
 class _AskDontCare extends AskValidator {
   const _AskDontCare();
   @override
-  String validate(String line) => line;
+  String validate(String line,String? customErrorMessage) => line;
 }
 
 /// The user must enter a non-empty string.
@@ -385,7 +388,7 @@ class _AskDontCare extends AskValidator {
 class _AskRequired extends AskValidator {
   const _AskRequired();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim();
     if (finalLine.isEmpty) {
       throw AskValidatorException(red('You must enter a value.'));
@@ -397,11 +400,11 @@ class _AskRequired extends AskValidator {
 class _AskEmail extends AskValidator {
   const _AskEmail();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim();
 
     if (!isEmail(finalLine)) {
-      throw AskValidatorException(red('Invalid email address.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid email address.'));
     }
     return finalLine;
   }
@@ -410,11 +413,11 @@ class _AskEmail extends AskValidator {
 class _AskFQDN extends AskValidator {
   const _AskFQDN();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim().toLowerCase();
 
     if (!isFQDN(finalLine)) {
-      throw AskValidatorException(red('Invalid FQDN.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid FQDN.'));
     }
     return finalLine;
   }
@@ -425,11 +428,11 @@ class _AskURL extends AskValidator {
 
   final List<String> protocols;
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim().toLowerCase();
 
     if (!isURL(finalLine, protocols: protocols)) {
-      throw AskValidatorException(red('Invalid URL.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid URL.'));
     }
     return finalLine;
   }
@@ -453,11 +456,11 @@ class _AskRegExp extends AskValidator {
   late final String _error;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim();
 
     if (!_regexp.hasMatch(finalLine)) {
-      throw AskValidatorException(red(_error));
+      throw AskValidatorException(red(customErrorMessage ?? _error));
     }
     return finalLine;
   }
@@ -466,11 +469,11 @@ class _AskRegExp extends AskValidator {
 class _AskDate extends AskValidator {
   const _AskDate();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim();
 
     if (!isDate(finalLine)) {
-      throw AskValidatorException(red('Invalid date.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid date.'));
     }
     return finalLine;
   }
@@ -479,12 +482,12 @@ class _AskDate extends AskValidator {
 class _AskInteger extends AskValidator {
   const _AskInteger();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalLine = line.trim();
     verbose(() => 'AskInteger: $finalLine');
 
     if (!isInt(finalLine)) {
-      throw AskValidatorException(red('Invalid integer.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid integer.'));
     }
     return finalLine;
   }
@@ -493,11 +496,11 @@ class _AskInteger extends AskValidator {
 class _AskDecimal extends AskValidator {
   const _AskDecimal();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
     if (!isFloat(finalline)) {
-      throw AskValidatorException(red('Invalid decimal number.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid decimal number.'));
     }
     return finalline;
   }
@@ -506,11 +509,11 @@ class _AskDecimal extends AskValidator {
 class _AskAlpha extends AskValidator {
   const _AskAlpha();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
     if (!isAlpha(finalline)) {
-      throw AskValidatorException(red('Alphabetical characters only.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Alphabetical characters only.'));
     }
     return finalline;
   }
@@ -519,11 +522,11 @@ class _AskAlpha extends AskValidator {
 class _AskAlphaNumeric extends AskValidator {
   const _AskAlphaNumeric();
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
     if (!isAlphanumeric(finalline)) {
-      throw AskValidatorException(red('Alphanumerical characters only.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Alphanumerical characters only.'));
     }
     return finalline;
   }
@@ -553,11 +556,11 @@ class AskValidatorIPAddress extends AskValidator {
   final int version;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     assert(
-      version == either || version == ipv4 || version == ipv6,
-      'The version nmust be AskValidatorIPAddress.either or '
-      'AskValidatorIPAddress.ipv4 or AskValidatorIPAddress.ipv6',
+    version == either || version == ipv4 || version == ipv6,
+    'The version nmust be AskValidatorIPAddress.either or '
+        'AskValidatorIPAddress.ipv4 or AskValidatorIPAddress.ipv6',
     );
 
     final finalline = line.trim();
@@ -573,7 +576,7 @@ class AskValidatorIPAddress extends AskValidator {
     }
 
     if (!isIP(finalline, version: validatorsVersion)) {
-      throw AskValidatorException(red('Invalid IP Address.'));
+      throw AskValidatorException(red(customErrorMessage ?? 'Invalid IP Address.'));
     }
     return finalline;
   }
@@ -586,13 +589,13 @@ class _AskValidatorMaxLength extends AskValidator {
   /// than [maxLength].
   const _AskValidatorMaxLength(this.maxLength);
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
     if (finalline.length > maxLength) {
       throw AskValidatorException(
         red(
-          'You have exceeded the maximum length of $maxLength characters.',
+          customErrorMessage ?? 'You have exceeded the maximum length of $maxLength characters.',
         ),
       );
     }
@@ -610,12 +613,12 @@ class _AskValidatorMinLength extends AskValidator {
   /// than [minLength].
   const _AskValidatorMinLength(this.minLength);
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
     if (finalline.length < minLength) {
       throw AskValidatorException(
-        red('You must enter at least $minLength characters.'),
+        red(customErrorMessage ?? 'You must enter at least $minLength characters.'),
       );
     }
     return finalline;
@@ -640,10 +643,10 @@ class _AskValidatorLength extends AskValidator {
   late _AskValidatorAll _validator;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
-    return _validator.validate(finalline);
+    return _validator.validate(finalline, customErrorMessage);
   }
 }
 
@@ -654,23 +657,23 @@ class _AskValidatorValueRange extends AskValidator {
   final num maxValue;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
 
     final value = num.tryParse(finalline);
     if (value == null) {
-      throw AskValidatorException(red('Must be a number.'));
+      throw AskValidatorException(customErrorMessage ?? red('Must be a number.'));
     }
 
     if (value < minValue) {
       throw AskValidatorException(
-        red('The number must be greater than or equal to $minValue.'),
+        red(customErrorMessage ?? 'The number must be greater than or equal to $minValue.'),
       );
     }
 
     if (value > maxValue) {
       throw AskValidatorException(
-        red('The number must be less than or equal to $maxValue.'),
+        red(customErrorMessage ?? 'The number must be less than or equal to $maxValue.'),
       );
     }
 
@@ -706,11 +709,11 @@ class _AskValidatorAll extends AskValidator {
   final List<AskValidator> _validators;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     var finalline = line.trim();
 
     for (final validator in _validators) {
-      finalline = validator.validate(finalline);
+      finalline = validator.validate(finalline, customErrorMessage);
     }
     return finalline;
   }
@@ -747,7 +750,7 @@ class _AskValidatorAny extends AskValidator {
   final List<AskValidator> _validators;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     var finalline = line.trim();
 
     AskValidatorException? firstFailure;
@@ -756,7 +759,7 @@ class _AskValidatorAny extends AskValidator {
 
     for (final validator in _validators) {
       try {
-        finalline = validator.validate(finalline);
+        finalline = validator.validate(finalline, customErrorMessage);
         onePassed = true;
       } on AskValidatorException catch (e) {
         firstFailure ??= e;
@@ -786,7 +789,7 @@ class _AskValidatorList extends AskValidator {
   final bool caseSensitive;
 
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     var finalline = line.trim();
 
     if (caseSensitive) {
@@ -806,7 +809,7 @@ class _AskValidatorList extends AskValidator {
     }
     if (!found) {
       throw AskValidatorException(
-        red('The valid responses are ${validItems.join(' | ')}.'),
+        red(customErrorMessage ?? 'The valid responses are ${validItems.join(' | ')}.'),
       );
     }
 

--- a/dcli/lib/src/functions/menu.dart
+++ b/dcli/lib/src/functions/menu.dart
@@ -163,7 +163,7 @@ class Menu {
 class _MenuRange extends AskValidator {
   const _MenuRange(this.limit);
   @override
-  String validate(String line) {
+  String validate(String line, String? customErrorMessage) {
     final finalline = line.trim();
     final value = num.tryParse(finalline);
     if (value == null) {

--- a/dcli/lib/src/functions/menu.dart
+++ b/dcli/lib/src/functions/menu.dart
@@ -163,7 +163,7 @@ class Menu {
 class _MenuRange extends AskValidator {
   const _MenuRange(this.limit);
   @override
-  String validate(String line, String? customErrorMessage) {
+  String validate(String line, {String? customErrorMessage}) {
     final finalline = line.trim();
     final value = num.tryParse(finalline);
     if (value == null) {

--- a/dcli/test/src/functions/ask_test.dart
+++ b/dcli/test/src/functions/ask_test.dart
@@ -58,7 +58,7 @@ void main() {
       final validator = Ask.regExp(r'^[a-zA-Z0-9_\-]+');
 
       expect(
-        () => validator.validate('!'),
+        () => validator.validate('!',null),
         throwsA(
           predicate<AskValidatorException>(
             (e) => e.message == red(r'Input does not match: ^[a-zA-Z0-9_\-]+'),
@@ -66,7 +66,7 @@ void main() {
         ),
       );
 
-      expect(validator.validate('_'), '_');
+      expect(validator.validate('_',null), '_');
     },
     skip: false,
   );
@@ -78,7 +78,7 @@ void main() {
       Ask.inList(['localhost'])
     ]);
 
-    expect('localhost', validator.validate('localhost'));
+    expect('localhost', validator.validate('localhost',null));
   });
 
   test('ask.any - throws', () {
@@ -89,10 +89,27 @@ void main() {
     ]);
 
     expect(
-      () => validator.validate('abc'),
+      () => validator.validate('abc',null),
       throwsA(
         predicate<AskValidatorException>(
           (e) => e.message == red('Invalid FQDN.'),
+        ),
+      ),
+    );
+  });
+
+  test('ask.any - throws with custom error message', () {
+    final validator = Ask.any([
+      Ask.fqdn,
+      Ask.ipAddress(),
+      Ask.inList(['localhost'])
+    ]);
+
+    expect(
+          () => validator.validate('abc','Invalid domain!'),
+      throwsA(
+        predicate<AskValidatorException>(
+              (e) => e.message == red('Invalid domain!'),
         ),
       ),
     );
@@ -105,7 +122,7 @@ void main() {
       Ask.inList(['11', '12', '13'])
     ]);
 
-    expect('11', validator.validate('11'));
+    expect('11', validator.validate('11',null));
   });
 
   test('ask.all - failure', () {
@@ -116,7 +133,7 @@ void main() {
     ]);
 
     expect(
-      () => validator.validate('9'),
+      () => validator.validate('9',null),
       throwsA(
         isA<AskValidatorException>().having(
           (e) => e.message,
@@ -127,11 +144,30 @@ void main() {
     );
   });
 
+  test('ask.all - failure with custom message', () {
+    final validator = Ask.all([
+      Ask.integer,
+      Ask.valueRange(10, 25),
+      Ask.inList(['11', '12', '13'])
+    ]);
+
+    expect(
+          () => validator.validate('9','Number must be >= 10'),
+      throwsA(
+        isA<AskValidatorException>().having(
+              (e) => e.message,
+          'message',
+          equals(red('Number must be >= 10')),
+        ),
+      ),
+    );
+  });
+
   test('ask.integer - failure', () {
     const validator = Ask.integer;
 
     expect(
-      () => validator.validate('a'),
+      () => validator.validate('a',null),
       throwsA(
         predicate<AskValidatorException>(
           (e) => e.message == red('Invalid integer.'),
@@ -139,6 +175,21 @@ void main() {
       ),
     );
 
-    expect(validator.validate('9'), equals('9'));
+    expect(validator.validate('9',null), equals('9'));
+  });
+
+  test('ask.integer - failure', () {
+    const validator = Ask.integer;
+
+    expect(
+          () => validator.validate('a','You must enter integer value!'),
+      throwsA(
+        predicate<AskValidatorException>(
+              (e) => e.message == red('You must enter integer value!'),
+        ),
+      ),
+    );
+
+    expect(validator.validate('9',null), equals('9'));
   });
 }

--- a/dcli/test/src/functions/ask_test.dart
+++ b/dcli/test/src/functions/ask_test.dart
@@ -58,7 +58,7 @@ void main() {
       final validator = Ask.regExp(r'^[a-zA-Z0-9_\-]+');
 
       expect(
-        () => validator.validate('!',null),
+        () => validator.validate('!'),
         throwsA(
           predicate<AskValidatorException>(
             (e) => e.message == red(r'Input does not match: ^[a-zA-Z0-9_\-]+'),
@@ -66,7 +66,7 @@ void main() {
         ),
       );
 
-      expect(validator.validate('_',null), '_');
+      expect(validator.validate('_'), '_');
     },
     skip: false,
   );
@@ -78,7 +78,7 @@ void main() {
       Ask.inList(['localhost'])
     ]);
 
-    expect('localhost', validator.validate('localhost',null));
+    expect('localhost', validator.validate('localhost'));
   });
 
   test('ask.any - throws', () {
@@ -89,7 +89,7 @@ void main() {
     ]);
 
     expect(
-      () => validator.validate('abc',null),
+      () => validator.validate('abc'),
       throwsA(
         predicate<AskValidatorException>(
           (e) => e.message == red('Invalid FQDN.'),
@@ -106,10 +106,10 @@ void main() {
     ]);
 
     expect(
-          () => validator.validate('abc','Invalid domain!'),
+      () => validator.validate('abc', customErrorMessage: 'Invalid domain!'),
       throwsA(
         predicate<AskValidatorException>(
-              (e) => e.message == red('Invalid domain!'),
+          (e) => e.message == red('Invalid domain!'),
         ),
       ),
     );
@@ -122,7 +122,7 @@ void main() {
       Ask.inList(['11', '12', '13'])
     ]);
 
-    expect('11', validator.validate('11',null));
+    expect('11', validator.validate('11'));
   });
 
   test('ask.all - failure', () {
@@ -133,7 +133,7 @@ void main() {
     ]);
 
     expect(
-      () => validator.validate('9',null),
+      () => validator.validate('9'),
       throwsA(
         isA<AskValidatorException>().having(
           (e) => e.message,
@@ -152,10 +152,10 @@ void main() {
     ]);
 
     expect(
-          () => validator.validate('9','Number must be >= 10'),
+      () => validator.validate('9', customErrorMessage: 'Number must be >= 10'),
       throwsA(
         isA<AskValidatorException>().having(
-              (e) => e.message,
+          (e) => e.message,
           'message',
           equals(red('Number must be >= 10')),
         ),
@@ -167,7 +167,7 @@ void main() {
     const validator = Ask.integer;
 
     expect(
-      () => validator.validate('a',null),
+      () => validator.validate('a'),
       throwsA(
         predicate<AskValidatorException>(
           (e) => e.message == red('Invalid integer.'),
@@ -175,21 +175,22 @@ void main() {
       ),
     );
 
-    expect(validator.validate('9',null), equals('9'));
+    expect(validator.validate('9'), equals('9'));
   });
 
   test('ask.integer - failure', () {
     const validator = Ask.integer;
 
     expect(
-          () => validator.validate('a','You must enter integer value!'),
+      () => validator.validate('a',
+          customErrorMessage: 'You must enter integer value!'),
       throwsA(
         predicate<AskValidatorException>(
-              (e) => e.message == red('You must enter integer value!'),
+          (e) => e.message == red('You must enter integer value!'),
         ),
       ),
     );
 
-    expect(validator.validate('9',null), equals('9'));
+    expect(validator.validate('9'), equals('9'));
   });
 }


### PR DESCRIPTION
Hello, so i have been using **dcli** with my dart CLI apps and i faced this **limitation** where i can't show my own **error message** so i figured out, why not to add it, it would be amazing to tell user what went wrong in any way i like, so in this pull request i did that and now we can use ask function this way to show our own custom error message.

```dart
String name = ask(
      'Enter your name',
      required: true,
      validator: Ask.regExp(r'^[a-zA-Z\s_]+$'), // name must be alphabetic
      customErrorMessage: 'Please enter a valid name!',
    );
// if input was not alphabetic for ex: 1999 it will show our custom error message
// instead of showing default message -> Input does not match: ^[a-zA-Z\s_]+$
```

- [x] Add new parameter called **customErrorMessage** to **ask** function 🚀
- [x] Write test code for the new feature 🧪
